### PR TITLE
Implement manual language switching in settings page

### DIFF
--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -6,6 +6,16 @@
     "todos": "Todo",
     "settings": "Settings"
   },
+  "settings": {
+    "title": "Settings",
+    "language": {
+      "title": "Language",
+      "description": "Select your preferred language",
+      "english": "English",
+      "polish": "Polish",
+      "current": "Current language: {{language}}"
+    }
+  },
   "loading": "Loading...",
   "error": "Something went wrong",
   "retry": "Try again"

--- a/apps/frontend/public/locales/pl/common.json
+++ b/apps/frontend/public/locales/pl/common.json
@@ -6,6 +6,16 @@
     "todos": "Zadania",
     "settings": "Ustawienia"
   },
+  "settings": {
+    "title": "Ustawienia",
+    "language": {
+      "title": "Język",
+      "description": "Wybierz preferowany język",
+      "english": "Angielski",
+      "polish": "Polski",
+      "current": "Bieżący język: {{language}}"
+    }
+  },
   "loading": "Ładowanie...",
   "error": "Coś poszło nie tak",
   "retry": "Spróbuj ponownie"

--- a/apps/frontend/src/components/LanguageSwitcher.tsx
+++ b/apps/frontend/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
+
+export default function LanguageSwitcher() {
+  const { t, i18n } = useTranslation('common');
+  const router = useRouter();
+
+  const languages = [
+    { code: 'en', name: t('settings.language.english') },
+    { code: 'pl', name: t('settings.language.polish') },
+  ];
+
+  const handleLanguageChange = async (locale: string) => {
+    // Use Next.js router to change locale
+    await router.push(router.asPath, router.asPath, { locale });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        {t('settings.language.title')}
+      </h3>
+      <p className="text-gray-600 mb-4">
+        {t('settings.language.description')}
+      </p>
+      
+      {/* Current language indicator */}
+      <div className="mb-4 p-3 bg-blue-50 rounded-md">
+        <p className="text-sm text-blue-800">
+          {t('settings.language.current', { 
+            language: languages.find(lang => lang.code === i18n.language)?.name 
+          })}
+        </p>
+      </div>
+
+      {/* Language options */}
+      <div className="space-y-2">
+        {languages.map((language) => (
+          <button
+            key={language.code}
+            onClick={() => handleLanguageChange(language.code)}
+            className={`
+              w-full text-left px-4 py-3 rounded-md border transition-colors duration-200
+              ${
+                i18n.language === language.code
+                  ? 'bg-primary-50 border-primary-200 text-primary-700'
+                  : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50 hover:border-gray-300'
+              }
+            `}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-medium">{language.name}</span>
+              {i18n.language === language.code && (
+                <svg
+                  className="h-5 w-5 text-primary-600"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/settings.tsx
+++ b/apps/frontend/src/pages/settings.tsx
@@ -2,19 +2,28 @@ import { GetStaticProps } from 'next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { useTranslation } from 'next-i18next';
 import Layout from '../components/Layout';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 
 export default function Settings() {
   const { t } = useTranslation('common');
 
   return (
     <Layout>
-      <div className="p-6">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">
-          {t('nav.settings')}
+      <div className="p-6 max-w-4xl">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">
+          {t('settings.title')}
         </h1>
-        <p className="text-gray-600">
-          Settings page placeholder - language switcher will be implemented here.
-        </p>
+        
+        <div className="space-y-6">
+          <LanguageSwitcher />
+          
+          {/* Placeholder for future settings */}
+          <div className="bg-gray-50 rounded-lg p-6 border-2 border-dashed border-gray-200">
+            <p className="text-gray-500 text-center">
+              Additional settings will be added here in the future.
+            </p>
+          </div>
+        </div>
       </div>
     </Layout>
   );


### PR DESCRIPTION
- Create LanguageSwitcher component with English/Polish selection
- Add visual feedback for current language with highlighted selection
- Update translation files with settings and language switcher text
- Enhance settings page with proper language switching functionality
- Use Next.js router for instant locale switching without page reload
- Add responsive design with hover effects and accessibility features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a language switcher to the settings page, allowing users to change the app's language between English and Polish.
- **Enhancements**
	- Updated localization files with new strings for settings and language selection in both English and Polish.
	- Improved the settings page layout and added placeholders for future options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->